### PR TITLE
3.0

### DIFF
--- a/src/Adapter/Reporter/HttpClientFactory.php
+++ b/src/Adapter/Reporter/HttpClientFactory.php
@@ -41,7 +41,7 @@ class HttpClientFactory implements ClientFactory
                 'no_aspect' => true,
             ]);
             $statusCode = $response->getStatusCode();
-            if ($statusCode !== 202) {
+            if (! in_array($statusCode, [200, 202], true)) {
                 throw new RuntimeException(
                     sprintf('Reporting of spans failed, status code %d', $statusCode)
                 );

--- a/src/Adapter/Reporter/ReporterFactory.php
+++ b/src/Adapter/Reporter/ReporterFactory.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  */
 namespace Hyperf\Tracer\Adapter\Reporter;
 
+use Hyperf\Contract\StdoutLoggerInterface;
 use RuntimeException;
 use Zipkin\Reporter;
 
@@ -20,18 +21,18 @@ class ReporterFactory
 {
     public function __construct(
         private HttpClientFactory $httpClientFactory,
+        private StdoutLoggerInterface $logger
     ) {
     }
 
     public function make(array $option = []): Reporter
     {
         $class = $option['class'] ?? '';
-        $constructor = $option['constructor'] ?? [];
 
         if ($class === \Zipkin\Reporters\Http::class) {
             $option['constructor']['requesterFactory'] = $this->httpClientFactory;
         }
-
+        $constructor = $option['constructor'] ?? [];
         if (! class_exists($class)) {
             throw new RuntimeException(sprintf('Class %s is not exists.', $class));
         }

--- a/src/Adapter/Reporter/ReporterFactory.php
+++ b/src/Adapter/Reporter/ReporterFactory.php
@@ -31,6 +31,7 @@ class ReporterFactory
 
         if ($class === \Zipkin\Reporters\Http::class) {
             $option['constructor']['requesterFactory'] = $this->httpClientFactory;
+            $option['constructor']['logger'] = $this->logger;
         }
         $constructor = $option['constructor'] ?? [];
         if (! class_exists($class)) {


### PR DESCRIPTION
处理了链路追踪使用zipkin时的3个问题：
1.requesterFactory之前试图替换为hyperf的httpClientFactory。但是没有生效。

2.zipkin上报后，服务端的响应可以是200，也可以是202，但是目前限制死了只能为202，导致每次服务端正确响应后，都new 了一个Runtime异常。我查看了openzipkin/zipkin-go客户端，它允许服务端响应状态码为200~299。 从实际出发，阿里云、火山云的链路追踪，上报后的http状态码是200而不是202。

3.创建http上报对象时，传入了logger类，便于发生了Runtime异常时定位原因
